### PR TITLE
mflash: fix build with gcc 9.1.0

### DIFF
--- a/src/flash/mflash.c
+++ b/src/flash/mflash.c
@@ -1153,13 +1153,16 @@ static void mg_gen_ataid(mg_io_type_drv_info *pSegIdDrvInfo)
 	/* Advanced power management level 1 */
 	pSegIdDrvInfo->adv_pwr_mgm_lvl_val                      = 0x0;
 	pSegIdDrvInfo->reserved5                        = 0x0;
+	/* mg_io_uint16 re_of_hw_rst uninitialized? */
 	memset(pSegIdDrvInfo->reserved6, 0x00, 68);
 	/* Security mode feature is disabled */
 	pSegIdDrvInfo->security_stas                    = 0x0;
 	memset(pSegIdDrvInfo->vendor_uniq_bytes, 0x00, 62);
 	/* CFA power mode 1 support in maximum 200mA */
 	pSegIdDrvInfo->cfa_pwr_mode                     = 0x0100;
-	memset(pSegIdDrvInfo->reserved7, 0x00, 190);
+	memset(pSegIdDrvInfo->reserved7, 0x00, 186);
+	pSegIdDrvInfo->scts_per_secure_data_unit        = 0x0;
+	pSegIdDrvInfo->integrity_word                   = 0x0;
 }
 
 static int mg_storage_config(void)


### PR DESCRIPTION
Source: http://openocd.zylin.com/gitweb?p=openocd.git;a=commitdiff;h=f7e624fa7112e9e673011f75c23f812d5f89420c
mflash: fix build with gcc 9.1.0

With new gcc we get compile time error:
	In function ‘mg_gen_ataid’,
	    inlined from ‘mg_storage_config’ at src/flash/mflash.c:1174:2:
	src/flash/mflash.c:1162:2: error: ‘memset’ offset [509, 512] from the
	 object at ‘buff’ is out of the bounds of referenced subobject
	 ‘reserved7’ with type ‘mg_io_uint8[186]’ {aka ‘unsigned char[186]’}
	 at offset 322 [-Werror=array-bounds]
	1162 |  memset(pSegIdDrvInfo->reserved7, 0x00, 190);

Since its first submission in 2009, mflash code has this field
	mg_io_uint8 reserved7[186];
that is memset for 190 bytes, clearly overflowing.
The 4 bytes after reserved7[] in the struct belong to fields that
are not used, so the overflow is not damaging anything, but is
probably a crap way to initialize them too.

Reduce the memset parameter to stay within the array size.
Explicitly initialize the remaining fields so the behaviour is
not changed.
Add a comment for the field "re_of_hw_rst" that is the only one
not properly initialized. Bug?

Change-Id: I6f637cc800d61d4365575be07b7f50e73bdd0ca5
Signed-off-by: Antonio Borneo <borneo.antonio@gmail.com>