### PR TITLE
Update mflash.c - memset out of bounds

### DIFF
--- a/src/flash/mflash.c
+++ b/src/flash/mflash.c
@@ -1159,7 +1159,7 @@ static void mg_gen_ataid(mg_io_type_drv_info *pSegIdDrvInfo)
 	memset(pSegIdDrvInfo->vendor_uniq_bytes, 0x00, 62);
 	/* CFA power mode 1 support in maximum 200mA */
 	pSegIdDrvInfo->cfa_pwr_mode                     = 0x0100;
-	memset(pSegIdDrvInfo->reserved7, 0x00, 190);
+	memset(pSegIdDrvInfo->reserved7, 0x00, 186);
 }
 
 static int mg_storage_config(void)


### PR DESCRIPTION
> In function ‘mg_gen_ataid’,
>     inlined from ‘mg_storage_config’ at src/flash/mflash.c:1174:2:
> src/flash/mflash.c:1162:2: error: ‘memset’ offset [509, 512] from the object at ‘buff’ is out of the bounds of referenced subobject ‘reserved7’ with type ‘mg_io_uint8[186]’ {aka ‘unsigned char[186]’} at offset 322 [-Werror=array-bounds]
>  1162 |  memset(pSegIdDrvInfo->reserved7, 0x00, 190);
>       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> cc1: all warnings being treated as errors
> make[2]: *** [Makefile:3344: src/flash/mflash.lo] Erro 1