### PR TITLE
drivers/ftdi: fix an incompatible pointer type error

### DIFF
--- a/src/jtag/drivers/ftdi.c
+++ b/src/jtag/drivers/ftdi.c
@@ -1079,7 +1079,7 @@ static void oscan1_reset_online_activate(void)
 		}
 		uint32_t back0 = 0x00;
 		/* CRSCAN=32 */
-		oscan1_mpsse_clock_data(mpsse_ctx, NULL, 0, &back0, 0, 32, ftdi_jtag_mode);
+		oscan1_mpsse_clock_data(mpsse_ctx, NULL, 0, (uint8_t *)&back0, 0, 32, ftdi_jtag_mode);
 		uint32_t to_normal_seq[] = {
 			0x00000012,  9, /* SDR -> RTI */
 			0x00000000,  4, /* Check Packet */


### PR DESCRIPTION
Fix the build error:
```src/jtag/drivers/ftdi.c: In function 'oscan1_reset_online_activate':
src/jtag/drivers/ftdi.c:1082:61: error: passing argument 4 of 'oscan1_mpsse_clock_data' from incompatible pointer type [-Werror=incompatible-pointer-types]
 1082 |                 oscan1_mpsse_clock_data(mpsse_ctx, NULL, 0, &back0, 0, 32, ftdi_jtag_mode);
      |                                                             ^~~~~~
      |                                                             |
      |                                                             uint32_t * {aka unsigned int *}
src/jtag/drivers/ftdi.c:812:110: note: expected 'uint8_t *' {aka 'unsigned char *'} but argument is of type 'uint32_t *' {aka 'unsigned int *'}
  812 | static void oscan1_mpsse_clock_data(struct mpsse_ctx *ctx, const uint8_t *out, unsigned out_offset, uint8_t *in,
      |                                                                                                     ~~~~~~~~~^~
cc1: all warnings being treated as errors
```

Tested on archlinux, GCC 13.2.1.